### PR TITLE
use environment variables to switch between API, DP roots

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     image: argovis/argo-express:dev
     user: 1000830000:1000830000
     restart: always
+    environment:
+      ARGOVIS_API_ROOT: 'http://127.0.0.1:8080'
+      ARGOVIS_DP_ROOT: 'http://127.0.0.1:3030'
     ports: 
     - '3000:3000'
   database:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,9 @@
 # entrypoint for angular frontend
-# usage: bash docker-entrypoint.sh <IP and port of API> <IP and port of datapages service>
+# usage: set environment variables ARGOVIS_API_ROOT and ARGOVIS_DP_ROOT, then bash docker-entrypoint.sh 
 
 # need to sub in API adress in client-side code at runtime startup:
-sed -i "s|ARGOVIS_API_ROOT|$1|g" /usr/src/ng_argovis/dist/main*.js
-sed -i "s|ARGOVIS_DP_ROOT|$2|g" /usr/src/ng_argovis/dist/main*.js
+sed -i "s|ARGOVIS_API_ROOT|$ARGOVIS_API_ROOT|g" /usr/src/ng_argovis/dist/main*.js
+sed -i "s|ARGOVIS_DP_ROOT|$ARGOVIS_DP_ROOT|g" /usr/src/ng_argovis/dist/main*.js
 
 # start app
 ./bin/www


### PR DESCRIPTION
Rather than hard-coding them into the entrypoint script. Any container orchestrator can provision these at runtime, avoiding the need for rebuilds per environment.