### PR TITLE
custom axis homing button for plotly

### DIFF
--- a/src/app/profview/profview.component.html
+++ b/src/app/profview/profview.component.html
@@ -1,6 +1,6 @@
 <mat-grid-list id=varplots cols="12" gutterSize="0px" rowHeight="500px">
     <mat-grid-tile id=chartA [colspan]="6" [rowspan]="1">
-        <app-varplot defaultX="temp" defaultY="pres" defaultZ="psal" width=600></app-varplot>
+        <app-varplot tag="plotA" defaultX="temp" defaultY="pres" defaultZ="psal" width=600></app-varplot>
     </mat-grid-tile>
     <mat-grid-tile [colspan]="6" [rowspan]="1">
         <app-globe-scatter id="globe-scatter-chart"></app-globe-scatter>
@@ -9,7 +9,7 @@
 
 <mat-grid-list id=varplots cols="12" gutterSize="0px" rowHeight="500px">
     <mat-grid-tile id=chartB [colspan]="12" [rowspan]="1">
-        <app-varplot defaultX="time" defaultY="pres" defaultZ="doxy" width=1200></app-varplot>
+        <app-varplot tag="plotB" defaultX="time" defaultY="pres" defaultZ="doxy" width=1200></app-varplot>
     </mat-grid-tile>
 </mat-grid-list>
 

--- a/src/app/profview/varplot/varplot.component.html
+++ b/src/app/profview/varplot/varplot.component.html
@@ -54,6 +54,7 @@
     <plotly-plot *ngIf="graph" class='chart'
       [data]="graph.data"
       [layout]="graph.layout"
+      [config]="graph.config"
       (plotly_click)="on_select($event)">
     </plotly-plot>
 </div>

--- a/src/app/profview/varplot/varplot.component.ts
+++ b/src/app/profview/varplot/varplot.component.ts
@@ -18,6 +18,7 @@ export class VarplotComponent implements OnInit, AfterViewInit, OnChanges {
   @Input() defaultY: any
   @Input() defaultZ: any
   @Input() width: any
+  @Input() tag: any
   public platform_number: string
   public xAxis: string
   public yAxis: string
@@ -200,7 +201,23 @@ export class VarplotComponent implements OnInit, AfterViewInit, OnChanges {
       // update graph on change
       this.graph = {
         data: data,
-        layout: this.generate_layout(this.yAxis.includes('pres'), data.length <= 10)
+        layout: this.generate_layout(this.yAxis.includes('pres'), data.length <= 10),
+        // config adds / removes modbar buttons
+        config: {
+          modeBarButtonsToRemove: ['resetScale2d'],
+          modeBarButtonsToAdd: [{
+            name: 'Home Axes',
+            icon: {
+              'width': 500,
+              'height': 600,
+              'path': 'm786 296v-267q0-15-11-26t-25-10h-214v214h-143v-214h-214q-15 0-25 10t-11 26v267q0 1 0 2t0 2l321 264 321-264q1-1 1-4z m124 39l-34-41q-5-5-12-6h-2q-7 0-12 3l-386 322-386-322q-7-4-13-4-7 2-12 7l-35 41q-4 5-3 13t6 12l401 334q18 15 42 15t43-15l136-114v109q0 8 5 13t13 5h107q8 0 13-5t5-13v-227l122-102q5-5 6-12t-4-13z',
+              'transform': "matrix(0.7 0 0 -0.7 -100 600)" 
+            },
+            click: function(gd) {
+              this.make_chart()
+            }.bind(this)
+          }]
+        }
       }
     },
     error => {


### PR DESCRIPTION
by default only x/y are homed; this makes a home button that triggers our full plot update, returning all axes to their autodetected values.